### PR TITLE
Update README.md to replace Almond w/ AMDClean under 'What libraries hav...

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ The entire file is wrapped in an AMD define method, with all external module (fi
 
 **What libraries have you included?**
 
-   - Backbone, Require, Grunt, Lodash, Almond, jQuery, jQueryUI, jQuery Mobile, Twitter Bootstrap, and Jasmine (w/the jasmine-jquery plugin)
+   - Backbone, Require, Grunt, Lodash, AMDClean, jQuery, jQueryUI, jQuery Mobile, Twitter Bootstrap, and Jasmine (w/the jasmine-jquery plugin)
 
 **What Require.js plugins are you using?**
 


### PR DESCRIPTION
...e you included?'

Was referred to take a look at this boilerplate by a colleague. After reading the README I was confused if Almond.js was still included, as suggested in the 'What libraries have you included?' heading (because the CHANGELOG referenced it's replacement with AMDClean.js as of the 1.7.0 build).

Simply assuming this is an oversight in the README file, and submitting the pull request to prevent further confusion by readers to the reference of Almond. This should clear things up.
