### PR TITLE
fix amdclean npm package version for hassle free minification

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "grunt-karma": "~0.6.1",
     "karma-coverage": "~0.1.0",
     "webdriverjs": "~0.7.9",
-    "amdclean": "1.x",
+    "amdclean": "2.x",
     "grunt-contrib-uglify": "~0.3.2"
   }
 }


### PR DESCRIPTION
Hi, I had some trouble with minification on my app. After I looked at things, I realized that I had an older amdclean. After changing this package.json setting to the 2.x series, my minification worked just right. It's a cool framework, I like it a lot & it's a pretty good teaching tool as well. 

You might want to look at bumping some of those other package versions as well, I'm not too familiar with them.
