### PR TITLE
add reports in public dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 coverage/
 reports/
+public/reports/


### PR DESCRIPTION
The reports tend to generate in public and that path was not in gitignore. This adds it.
